### PR TITLE
T1069.001: Add SharpHound LocalAdmin attack

### DIFF
--- a/atomics/T1069.001/T1069.001.yaml
+++ b/atomics/T1069.001/T1069.001.yaml
@@ -38,3 +38,36 @@ atomic_tests:
       get-localgroup
       Get-LocalGroupMember -Name "Administrators"
     name: powershell
+- name: SharpHound3 - LocalAdmin
+  auto_generated_guid: e03ada14-0980-4107-aff1-7783b2b59bb1
+  description: |
+    This module runs the Windows executable of SharpHound in order to remotely list members of the local Administrators group (SAMR)
+  supported_platforms:
+  - windows
+  input_arguments:
+    domain_name:
+      description: FQDN of the targeted domain
+      type: string
+      default: DOMAIN.CORP
+    sharphound_path:
+      description: SharpHound Windows executable
+      type: path
+      default: '$env:TEMP\SharpHound.exe'
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      SharpHound binary must exist on disk and at specified location (#{sharphound_path})
+    prereq_command: |
+      $sharphound_path = cmd /c echo #{sharphound_path}
+      if (Test-Path $sharphound_path) { exit 0 } else { exit 1 }
+    get_prereq_command: |
+      $sharphound_path = cmd /c echo #{sharphound_path}
+      Invoke-WebRequest "https://github.com/BloodHoundAD/BloodHound/blob/e062fe73d73c015dccb37fae5089342d009b84b8/Collectors/SharpHound.exe?raw=true" -OutFile $sharphound_path
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      & "#{sharphound_path}" -d  #{domain_name} --CollectionMethod LocalAdmin --NoSaveCache
+      Write-Host "End of SharpHound attack"
+    cleanup_command: |
+      Remove-Item #{sharphound_path}

--- a/atomics/T1069.001/T1069.001.yaml
+++ b/atomics/T1069.001/T1069.001.yaml
@@ -56,7 +56,8 @@ atomic_tests:
   dependency_executor_name: powershell
   dependencies:
   - description: |
-      SharpHound binary must exist on disk and at specified location (#{sharphound_path})
+      SharpHound binary must exist on disk and at specified location (#{sharphound_path}).
+      And the computer must be domain joined (implicit authentication).
     prereq_command: |
       $sharphound_path = cmd /c echo #{sharphound_path}
       if (Test-Path $sharphound_path) { exit 0 } else { exit 1 }

--- a/atomics/T1069.001/T1069.001.yaml
+++ b/atomics/T1069.001/T1069.001.yaml
@@ -64,14 +64,13 @@ atomic_tests:
       And the computer must be domain joined (implicit authentication).
     prereq_command: |
       if (Test-Path "#{sharphound_path}") { exit 0 } else { exit 1 }
-      if (Test-Path "#{output_path}") { exit 0 } else { exit 1 }
     get_prereq_command: |
       Invoke-WebRequest "https://github.com/BloodHoundAD/BloodHound/blob/e062fe73d73c015dccb37fae5089342d009b84b8/Collectors/SharpHound.exe?raw=true" -OutFile "#{sharphound_path}"
-      New-Item -Path "#{output_path}" -ItemType Directory > $null
   executor:
     name: powershell
     elevation_required: false
     command: |
+      New-Item -Path "#{output_path}" -ItemType Directory > $null
       & "#{sharphound_path}" -d "#{domain_name}" --CollectionMethod LocalAdmin --NoSaveCache --OutputDirectory "#{output_path}"
     cleanup_command: |
       Remove-Item -Recurse #{output_path}

--- a/atomics/T1069.001/T1069.001.yaml
+++ b/atomics/T1069.001/T1069.001.yaml
@@ -53,22 +53,25 @@ atomic_tests:
       description: SharpHound Windows executable
       type: path
       default: '$env:TEMP\SharpHound.exe'
+    output_path:
+      description: Output for SharpHound
+      type: path
+      default: '$env:TEMP\SharpHound\'
   dependency_executor_name: powershell
   dependencies:
   - description: |
       SharpHound binary must exist on disk and at specified location (#{sharphound_path}).
       And the computer must be domain joined (implicit authentication).
     prereq_command: |
-      $sharphound_path = cmd /c echo #{sharphound_path}
-      if (Test-Path $sharphound_path) { exit 0 } else { exit 1 }
+      if (Test-Path "#{sharphound_path}") { exit 0 } else { exit 1 }
+      if (Test-Path "#{output_path}") { exit 0 } else { exit 1 }
     get_prereq_command: |
-      $sharphound_path = cmd /c echo #{sharphound_path}
-      Invoke-WebRequest "https://github.com/BloodHoundAD/BloodHound/blob/e062fe73d73c015dccb37fae5089342d009b84b8/Collectors/SharpHound.exe?raw=true" -OutFile $sharphound_path
+      Invoke-WebRequest "https://github.com/BloodHoundAD/BloodHound/blob/e062fe73d73c015dccb37fae5089342d009b84b8/Collectors/SharpHound.exe?raw=true" -OutFile "#{sharphound_path}"
+      New-Item -Path "#{output_path}" -ItemType Directory > $null
   executor:
     name: powershell
     elevation_required: false
     command: |
-      & "#{sharphound_path}" -d  #{domain_name} --CollectionMethod LocalAdmin --NoSaveCache
-      Write-Host "End of SharpHound attack"
+      & "#{sharphound_path}" -d "#{domain_name}" --CollectionMethod LocalAdmin --NoSaveCache --OutputDirectory "#{output_path}"
     cleanup_command: |
-      Remove-Item #{sharphound_path}
+      Remove-Item -Recurse #{output_path}


### PR DESCRIPTION
**Details:**
SharpHound3 is used by BloodHound tool to collect multiple data (https://github.com/BloodHoundAD/SharpHound3/). For this test, only the LocalAdmin collection method is executed.

This is based on the Windows binary that is provided by the author on Github, using a permalink URL.

**Testing:**
Local testing.

**Associated Issues:**
N.A.
