### PR TITLE
T1003.003 Add remote Shadow Copy creation and fix existing atomic

### DIFF
--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -60,7 +60,7 @@ atomic_tests:
     prereq_command: |
       if not exist #{vsc_name} (exit /b 1)
     get_prereq_command: |
-      echo Run "Invoke-AtomicTest T1003.003 -TestName 'Create Volume Shadow Copy with vassadmin'" to fulfuill this requirement
+      echo Run "Invoke-AtomicTest T1003.003 -TestName 'Create Volume Shadow Copy with vssadmin'" to fulfill this requirement
   - description: |
       Extract path must exist
     prereq_command: |

--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -122,9 +122,9 @@ atomic_tests:
   - windows
   input_arguments:
     drive_letter:
-      description: Drive letter to source VSC (including colon)
+      description: Drive letter to source VSC (including colon and backslash)
       type: String
-      default: 'C:'
+      default: 'C:\'
   dependencies:
   - description: |
       Target must be a Domain Controller

--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -122,9 +122,9 @@ atomic_tests:
   - windows
   input_arguments:
     drive_letter:
-      description: Drive letter to source VSC (including colon and backslash)
+      description: Drive letter to source VSC (including colon)
       type: String
-      default: 'C:\'
+      default: 'C:'
   dependencies:
   - description: |
       Target must be a Domain Controller

--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -60,7 +60,7 @@ atomic_tests:
     prereq_command: |
       if not exist #{vsc_name} (exit /b 1)
     get_prereq_command: |
-      echo Run "Invoke-AtomicTest T1003.003 -TestName 'Create Volume Shadow Copy with vssadmin'" to fulfill this requirement
+      echo Run "Invoke-AtomicTest T1003.003 -TestName 'Create Volume Shadow Copy with vassadmin'" to fulfuill this requirement
   - description: |
       Extract path must exist
     prereq_command: |

--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -138,6 +138,36 @@ atomic_tests:
     name: command_prompt
     elevation_required: true
 
+- name: Create Volume Shadow Copy remotely with WMI
+  auto_generated_guid: d893459f-71f0-484d-9808-ec83b2b64226
+  description: |
+    This test is intended to be run from a remote workstation with domain admin context.
+
+    The Active Directory database NTDS.dit may be dumped by copying it from a Volume Shadow Copy.
+  supported_platforms:
+  - windows
+  input_arguments:
+    drive_letter:
+      description: Drive letter to source VSC (including colon and backslash)
+      type: String
+      default: 'C:\'
+    target_host:
+      description: IP Address / Hostname you want to target
+      type: String
+      default: dc.example.net
+  dependencies:
+  - description: |
+      Target must be a reachable Domain Controller, and current context must be domain admin
+    prereq_command: |
+      wmic /node:#{target_host} shadowcopy list brief
+    get_prereq_command: |
+      echo Sorry, can't connect to target host, check: network, firewall or permissions (must be admin on target)
+  executor:
+    command: |
+      wmic /node:#{target_host} shadowcopy call create Volume=#{drive_letter}
+    name: command_prompt
+    elevation_required: false
+
 - name: Create Volume Shadow Copy with Powershell
   auto_generated_guid: 542bb97e-da53-436b-8e43-e0a7d31a6c24
   description: |


### PR DESCRIPTION
**Details:**
For T1003.003:
* Add a new Atomic to allow remote Shadow Copy creation over wmi
* Fix the existing (local) wmi atomic, that would fail with the default `drive_letter` option due to a missing trailing backslash
* Fixing some typos

**Testing:**
Local testing

![Screenshot 2021-10-01 111450](https://user-images.githubusercontent.com/6689144/135600442-9fba2af4-a5b5-4d97-8511-680901694764.png)

**Associated Issues:**
N/A