### PR TITLE
 Add quotes for wmic node

### DIFF
--- a/atomics/T1003.003/T1003.003.yaml
+++ b/atomics/T1003.003/T1003.003.yaml
@@ -164,7 +164,7 @@ atomic_tests:
       echo Sorry, can't connect to target host, check: network, firewall or permissions (must be admin on target)
   executor:
     command: |
-      wmic /node:#{target_host} shadowcopy call create Volume=#{drive_letter}
+      wmic /node:"#{target_host}" shadowcopy call create Volume=#{drive_letter}
     name: command_prompt
     elevation_required: false
 


### PR DESCRIPTION

**Details:**
Quoting wmic node option prevents the command from failing when the destination node dns name contains a hyphen

**Testing:**
Local testing

**Associated Issues:**
N/A