### PR TITLE
[T1187] Auto-calculate capture server IP

### DIFF
--- a/atomics/T1187/T1187.yaml
+++ b/atomics/T1187/T1187.yaml
@@ -15,7 +15,7 @@ atomic_tests:
     efsApi:
       description: EFS API to use to coerce authentication
       type: string
-      default: 1
+      default: 2
     petitpotam_path:
       description: PetitPotam Windows executable
       type: path


### PR DESCRIPTION
**Details:**
Auto-calculate capture server IP, because if the IP not not valid, the attack will not work.

**Testing:**
Manual tests.

**Associated Issues:**
None.