### PR TITLE
[T1069.001] SharpHound LocalAdmin Kerberos TGS purge

### DIFF
--- a/atomics/T1069.001/T1069.001.yaml
+++ b/atomics/T1069.001/T1069.001.yaml
@@ -71,6 +71,7 @@ atomic_tests:
     elevation_required: false
     command: |
       New-Item -Path "#{output_path}" -ItemType Directory > $null
+      klist purge
       & "#{sharphound_path}" -d "#{domain}" --CollectionMethod LocalAdmin --NoSaveCache --OutputDirectory "#{output_path}"
     cleanup_command: |
       Remove-Item -Recurse #{output_path}


### PR DESCRIPTION
**Details:**
I forgot to purge Kerberos TGS tickets, so right now, the attack can only be launched once. This would lead to inconsistent results without removing the previous TGS tickets from the cache.

**Testing:**
Manual test.

**Associated Issues:**
None